### PR TITLE
Add blog to top level navigation

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,6 +34,7 @@
           <li><a href="/">Home</a></li>
           <li><a href="/about" class="selected">About</a></li>
           <li><a href="/community">Community</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/docs">Docs</a></li>
         </ul>
       </nav>

--- a/community/index.html
+++ b/community/index.html
@@ -34,6 +34,7 @@
           <li><a href="/">Home</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/community" class="selected">Community</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/docs">Docs</a></li>
         </ul>
       </nav>

--- a/framework/index.html
+++ b/framework/index.html
@@ -36,6 +36,7 @@
           <li><a href="/">Home</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/community">Community</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/docs">Docs</a></li>
         </ul>
       </nav>

--- a/gateway/index.html
+++ b/gateway/index.html
@@ -33,6 +33,7 @@
           <li><a href="/">Home</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/community">Community</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/docs">Docs</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
           <li><a href="/" class="selected">Home</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/community">Community</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/docs">Docs</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
I've created an experimental WebThings blog hosted on GitHub Pages using a static site generator (Eleventy), so that we don't need to rely on [Medium](https://medium.com/webthingsio) any more. It's accessible at https://webthings.io/blog/ (source code at https://github.com/WebThingsIO/blog). So far there are just historical posts copied from Medium/MailChimp/Discourse.

This PR just adds a link to the blog to the top level navigation of the website.

(I've also added a new [WebThings Blog](https://github.com/WebThingsIO/wiki/wiki/Modules#webthings-blog) module to the wiki to track governance of the new repo.)

